### PR TITLE
Move Dockerfile to root and update build configuration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
       run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u andreasrg --password-stdin
 
     - name: Build image
-      run: docker build -f app/Dockerfile -t ghcr.io/andreasrg/awesome-recipe-book--2026-andreasrg-edition:latest .
+      run: docker build -t ghcr.io/andreasrg/awesome-recipe-book--2026-andreasrg-edition:latest .
 
     - name: Push image
       run: docker push ghcr.io/andreasrg/awesome-recipe-book--2026-andreasrg-edition:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Copy requirements
+COPY app/requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the FastAPI app code
+COPY app/ .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   app:
-    build: ./app
+    build: .
     container_name: exam-app
     expose:
       - "5000"


### PR DESCRIPTION
## Changes
- Moved Dockerfile from `app/Dockerfile` to root `Dockerfile`
- Updated docker-compose.yml to build from root context
- Updated GitHub Actions CD workflow to use root Dockerfile

## Benefits
- Cleaner build context and path references
- Simplified COPY commands in Dockerfile
- Consistent with Docker best practices

## Testing
- ✅ Docker build succeeds locally
- ✅ App starts without import errors
- ✅ Ready for Azure deployment