### PR TITLE
Fix test_data.json path in database.py

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -88,7 +88,7 @@ async def seed_database():
                 logger.info("Seeding database with test data...")
 
                 # Load test data from JSON file
-                with open("app/test_data.json", "r", encoding="utf-8") as f:
+                with open("test_data.json", "r", encoding="utf-8") as f:
                     data = json.load(f)
 
                 # Create ingredients


### PR DESCRIPTION
## Fix
Changed the hardcoded file path from `"app/test_data.json"` to `"test_data.json"` in [app/database.py](app/database.py#L91).

## Why
The test_data.json file is located in the same directory as database.py (the app folder). When uvicorn runs the app, it's already in that directory, so prefixing with "app/" causes a FileNotFoundError.

## Testing
- ✅ Tested locally with `uvicorn app:app --reload`
- ✅ Docker container starts successfully
- ✅ Database seeds with test data without errors